### PR TITLE
make using eff

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "purescript-prelude": "^3.0.0",
-    "purescript-aff": "^4.0.0"
+    "purescript-aff": "^4.1.0"
   },
   "devDependencies": {
     "purescript-refs": "^3.0.0"

--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -61,12 +61,14 @@ make ∷ ∀ m eff a. MonadEff (avar ∷ AVAR | eff) m => m (BusRW a)
 make = liftEff do
   cell ← EffAvar.makeEmptyVar
   consumers ← EffAvar.makeVar mempty
-  runAff_ (const $ pure unit) $ fix \loop →
-    attempt (takeVar cell) >>= traverse_ \res → do
+  let
+    loop = attempt (takeVar cell) >>= traverse_ \res → do
       vars ← takeVar consumers
       putVar mempty consumers
       sequence_ (foldl (\xs a → putVar res a : xs) mempty vars)
       loop
+  runAff_ (const $ pure unit) loop
+
   pure $ Bus cell consumers
 
 -- | Blocks until a new value is pushed to the Bus, returning the value.

--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -69,7 +69,6 @@ make = liftEff do
       loop
   pure $ Bus cell consumers
 
-
 -- | Blocks until a new value is pushed to the Bus, returning the value.
 read ∷ ∀ eff a r. BusR' r a → Aff (avar ∷ AVAR | eff) a
 read (Bus _ consumers) = do

--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -31,8 +31,7 @@ module Control.Monad.Aff.Bus
 
 import Prelude
 
-import Control.Lazy (fix)
-import Control.Monad.Aff (Aff, attempt, runAff_)
+import Control.Monad.Aff (Aff, attempt, launchAff_)
 import Control.Monad.Aff.AVar (AVAR, AVar, killVar, makeEmptyVar, putVar, takeVar)
 import Control.Monad.Eff.AVar as EffAvar
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
@@ -67,7 +66,7 @@ make = liftEff do
       putVar mempty consumers
       sequence_ (foldl (\xs a → putVar res a : xs) mempty vars)
       loop
-  runAff_ (const $ pure unit) loop
+  launchAff_ loop
 
   pure $ Bus cell consumers
 

--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -31,8 +31,10 @@ module Control.Monad.Aff.Bus
 
 import Prelude
 
-import Control.Monad.Aff (Aff, attempt, forkAff)
-import Control.Monad.Aff.AVar (AVAR, AVar, killVar, makeEmptyVar, makeVar, putVar, takeVar)
+import Control.Monad.Aff (Aff, attempt, runAff_)
+import Control.Monad.Aff.AVar (AVAR, AVar, killVar, makeEmptyVar, putVar, takeVar)
+import Control.Monad.Eff.AVar as EffAvar
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception as Exn
 import Data.Foldable (foldl, sequence_, traverse_)
 import Data.List (List, (:))
@@ -54,19 +56,20 @@ type BusW' r = Bus (write ∷ Cap | r)
 type BusRW = Bus (read ∷ Cap, write ∷ Cap)
 
 -- | Creates a new bidirectional Bus which can be read from and written to.
-make ∷ ∀ eff a. Aff (avar ∷ AVAR | eff) (BusRW a)
-make = do
-  cell ← makeEmptyVar
-  consumers ← makeVar mempty
+make ∷ ∀ m eff a. MonadEff (avar ∷ AVAR | eff) m => m (BusRW a)
+make = liftEff do
+  cell ← EffAvar.makeEmptyVar
+  consumers ← EffAvar.makeVar mempty
   let
-    loop = do
+    loop =
       attempt (takeVar cell) >>= traverse_ \res → do
         vars ← takeVar consumers
         putVar mempty consumers
         sequence_ (foldl (\xs a → putVar res a : xs) mempty vars)
         loop
-  _ ← forkAff loop
+  runAff_ (const $ pure unit) $ loop
   pure $ Bus cell consumers
+
 
 -- | Blocks until a new value is pushed to the Bus, returning the value.
 read ∷ ∀ eff a r. BusR' r a → Aff (avar ∷ AVAR | eff) a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -73,6 +73,7 @@ main ∷ Eff (Effects (exception ∷ EXCEPTION)) Unit
 main = do
   log "Testing read/write/kill..."
   runTest $ Bus.make >>= test_readWrite
+  runTest $ (liftEff Bus.make) >>= test_readWrite
   where
   runTest t = do
     isFinishedRef <- newRef false

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -91,5 +91,3 @@ main = do
             log "ok"
             writeRef isFinishedRef true
           else throwException $ error "failed"
-
-

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -57,10 +57,6 @@ test_readWrite bus = do
   Bus.write 2 bus
   Bus.write 3 bus
 
-  -- without delay kill of bus interpats pending interactions with avar
-  -- so we need to wait for some time to be sure that all actions are finished
-  delay $ Milliseconds 10.0
-  Bus.kill (error "Done") bus
 
   joinFiber f1
   joinFiber f2

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -56,6 +56,10 @@ test_readWrite bus = do
   Bus.write 1 bus
   Bus.write 2 bus
   Bus.write 3 bus
+
+  -- without delay kill of bus interpats pending interactions with avar
+  -- so we need to wait for some time to be sure that all actions are finished
+  delay $ Milliseconds 10.0
   Bus.kill (error "Done") bus
 
   joinFiber f1

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -57,6 +57,10 @@ test_readWrite bus = do
   Bus.write 2 bus
   Bus.write 3 bus
 
+  -- without delay kill of bus interpats pending interactions with avar
+  -- so we need to wait for some time to be sure that all actions are finished
+  delay $ Milliseconds 10.0
+  Bus.kill (error "Done") bus
 
   joinFiber f1
   joinFiber f2


### PR DESCRIPTION
Uses MonadEff instead of Aff in make, so one could make a bus in Eff contexts.
As MonadEff is used this change should be non braking.

also fixes #8