### PR TITLE
kill `consumers` var, so future `read` is not blocked; add isKilled

### DIFF
--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -33,8 +33,7 @@ module Control.Monad.Aff.Bus
 import Prelude
 
 import Control.Monad.Aff (Aff, attempt, launchAff_)
-import Control.Monad.Aff.AVar (AVAR, AVar, killVar, makeEmptyVar, putVar, takeVar)
-import Control.Monad.Eff.AVar (isKilledVar)
+import Control.Monad.Aff.AVar (AVAR, AVar, isKilledVarm, killVar, makeEmptyVar, putVar, takeVar)
 import Control.Monad.Eff.AVar as EffAvar
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception as Exn

--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -33,7 +33,7 @@ module Control.Monad.Aff.Bus
 import Prelude
 
 import Control.Monad.Aff (Aff, attempt, launchAff_)
-import Control.Monad.Aff.AVar (AVAR, AVar, isKilledVarm, killVar, makeEmptyVar, putVar, takeVar)
+import Control.Monad.Aff.AVar (AVAR, AVar, isKilledVar, killVar, makeEmptyVar, putVar, takeVar)
 import Control.Monad.Eff.AVar as EffAvar
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception as Exn

--- a/src/Control/Monad/Aff/Bus.purs
+++ b/src/Control/Monad/Aff/Bus.purs
@@ -33,7 +33,8 @@ module Control.Monad.Aff.Bus
 import Prelude
 
 import Control.Monad.Aff (Aff, attempt, launchAff_)
-import Control.Monad.Aff.AVar (AVAR, AVar, isKilledVar, killVar, makeEmptyVar, putVar, takeVar)
+import Control.Monad.Aff.AVar (AVAR, AVar, killVar, makeEmptyVar, putVar, takeVar)
+import Control.Monad.Eff.AVar (isKilledVar)
 import Control.Monad.Eff.AVar as EffAvar
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception as Exn


### PR DESCRIPTION
If bus is killed `read` blocks because of `takeVar consumers` so added `killVar err consumers` in `kill`, also added `isKilled` like in `avar`.